### PR TITLE
Add support for specifying tokens in chart

### DIFF
--- a/charts/appcat-service-s3/README.md
+++ b/charts/appcat-service-s3/README.md
@@ -1,0 +1,53 @@
+# appcat-service-s3
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+VSHN-opinionated S3 operator for AppCat
+
+## Installation
+
+```bash
+helm repo add appcat-service-s3 https://vshn.github.io/appcat-service-s3
+helm install appcat-service-s3 appcat-service-s3/appcat-service-s3
+```
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+# appcat-service-s3
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+VSHN-opinionated S3 operator for AppCat
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy If set to empty, then Kubernetes default behaviour applies. |
+| image.registry | string | `"ghcr.io"` | Operator image registry |
+| image.repository | string | `"vshn/appcat-service-s3"` | Operator image repository |
+| image.tag | string | `"latest"` | Operator image tag |
+| imagePullSecrets | list | `[]` | List of image pull secrets if custom image is behind authentication. |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| operator.args | list | `[]` | Overrides arguments passed to the entrypoint |
+| podAnnotations | object | `{}` | Annotations to add to the Pod spec. |
+| podSecurityContext | object | `{}` | Security context to add to the Pod spec. |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` | Container security context |
+| service.annotations | object | `{}` | Annotations to add to the service |
+| service.port | int | `80` | Service port number |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and `.create` is `true`, a name is generated using the fullname template |
+| tokens.cloudscale | string | `""` | The cloudscale.ch API token |
+| tokens.externalSecretName | string | `""` | Name of the external secret if tokens are not managed by this chart.   See `templates/secret.yaml` to figure out how to setup the expected environment variables. |
+| tolerations | list | `[]` |  |
+

--- a/charts/appcat-service-s3/templates/deployment.yaml
+++ b/charts/appcat-service-s3/templates/deployment.yaml
@@ -38,6 +38,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                {{ if .Values.tokens.externalSecretName -}}
+                name: {{ .Values.tokens.externalSecretName }}
+                {{- else -}}
+                name: {{ include "appcat-service-s3.fullname" . }}
+                {{- end }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/charts/appcat-service-s3/templates/secret.yaml
+++ b/charts/appcat-service-s3/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.tokens.externalSecretName -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "appcat-service-s3.fullname" . }}
+  labels:
+    {{- include "appcat-service-s3.labels" . | nindent 4 }}
+data:
+  CLOUDSCALE_API_TOKEN: {{ .Values.tokens.cloudscale }}
+{{- end -}}

--- a/charts/appcat-service-s3/values.yaml
+++ b/charts/appcat-service-s3/values.yaml
@@ -19,6 +19,13 @@ operator:
   # -- Overrides arguments passed to the entrypoint
   args: []
 
+tokens:
+  # -- The cloudscale.ch API token
+  cloudscale: ""
+  # -- Name of the external secret if tokens are not managed by this chart.  
+  # See `templates/secret.yaml` to figure out how to setup the expected environment variables.
+  externalSecretName: ""
+
 # -- List of image pull secrets if custom image is behind authentication.
 imagePullSecrets: []
 nameOverride: ""
@@ -57,40 +64,13 @@ service:
   # -- Annotations to add to the service
   annotations: {}
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary

* Adds `tokens.cloudscale` value, that gets rendered into a Secret, which is loaded as environment variables in the operator pod
* Adds `tokens.externalSecretName` value that if set, uses the name of the externally managed secret instead.

Developed for #11 

## Checklist

<!--
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.
-->

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:appcat-service-s3`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
